### PR TITLE
Fix `content` `undefined` error

### DIFF
--- a/parser/meta.js
+++ b/parser/meta.js
@@ -25,7 +25,7 @@ function meta() {
       if (is(node, 'head')) {
         visit(node, (child) => {
           if (is(child, 'meta')) {
-            const { name, property, content } = child.properties
+            const { name, property, content = '' } = child.properties
             if (name === 'description') {
               file.data.description = content
             } else if (name === 'keywords') {


### PR DESCRIPTION
The following error is happening in production:

```
Cannot read property 'split' of undefined 
    /opt/build/repo/node_modules/netlify-plugin-search-index/parser/meta.js:32:40 visit
    /opt/build/repo/node_modules/unist-util-visit/index.js:27:12 overload
    /opt/build/repo/node_modules/unist-util-visit-parents/index.js:34:25 one
    /opt/build/repo/node_modules/unist-util-visit-parents/index.js:57:16 all
    /opt/build/repo/node_modules/unist-util-visit-parents/index.js:42:28 one
    /opt/build/repo/node_modules/unist-util-visit-parents/index.js:26:3 visitParents
    /opt/build/repo/node_modules/unist-util-visit/index.js:22:3 visit
    /opt/build/repo/node_modules/netlify-plugin-search-index/parser/meta.js:26:9 visit
    /opt/build/repo/node_modules/unist-util-visit/index.js:27:12 overload
    /opt/build/repo/node_modules/unist-util-visit-parents/index.js:34:25 one
```

This PR fixes this error.