### PR TITLE
Remove `plugin.name`

### DIFF
--- a/fixtures/generator.js
+++ b/fixtures/generator.js
@@ -101,7 +101,6 @@ async function fetchContent(res = [], max = 5, page = 1) {
 
 function netlifyPluginGenerateArticles() {
   return {
-    name: 'netlify-plugin-generate-article',
     async onPostBuild(opts) {
       const {
         pluginConfig: {

--- a/index.js
+++ b/index.js
@@ -16,7 +16,6 @@ const writeFile = promisify(fs.writeFile);
 
 function netlifyPluginSearchIndex(_) {
   return {
-    name: 'netlify-plugin-search-index',
     async onPostBuild(opts) {
       const {
         pluginConfig: {


### PR DESCRIPTION
The `plugin.name` property has been moved to the `manifest.yml`.