### PR TITLE
Rename `pluginConfig` to `inputs`

### DIFF
--- a/fixtures/generator.js
+++ b/fixtures/generator.js
@@ -104,12 +104,12 @@ function netlifyPluginGenerateArticles() {
     name: 'netlify-plugin-generate-article',
     async onPostBuild(opts) {
       const {
-        pluginConfig: {
+        inputs: {
           folder = 'articles'
         },
         constants: { BUILD_DIR }
       } = opts;
-      
+
       try {
         const articles = await fetchContent()
         articles.forEach(async (article) => {

--- a/fixtures/this.test.js
+++ b/fixtures/this.test.js
@@ -12,7 +12,7 @@ test('plugin fixture works', () => {
   return initPlugin
     .onPostBuild({
       // from netlify.yml
-      pluginConfig: {
+      inputs: {
         debugMode: false,
         exclude: ['/search.html', /^\/devnull\/.*/],
         generatedFunctionName: 'mySearchFunction',

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function netlifyPluginSearchIndex(_) {
     name: 'netlify-plugin-search-index',
     async onPostBuild(opts) {
       const {
-        pluginConfig: {
+        inputs: {
           exclude = [],
           generatedFunctionName = 'search',
           publishDirJSONFileName = 'searchIndex',


### PR DESCRIPTION
The `pluginConfig` argument has been renamed to `inputs`.