### PR TITLE
Remove `plugin.name`

### DIFF
--- a/fixtures/generator.js
+++ b/fixtures/generator.js
@@ -100,7 +100,6 @@ async function fetchContent(res = [], max = 5, page = 1) {
 }
 
 module.exports = {
-    name: 'netlify-plugin-generate-article',
     async onPostBuild(opts) {
       const {
         inputs: {

--- a/index.js
+++ b/index.js
@@ -15,7 +15,6 @@ const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
 
 module.exports = {
-    name: 'netlify-plugin-search-index',
     async onPostBuild(opts) {
       const {
         inputs: {


### PR DESCRIPTION
Fixes #16.

The `name` property of plugin was removed in #12 (`0158d443c6f164ce82149b580cd6bb94a0d9cfee`) but accidentally added back in `9fec2c0348480f54e0a3d7f28688fac8202e0e5f`. This PR fixes this.