### PR TITLE
Add limit query param to search

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,12 @@ You can use this plugin in two ways:
     // app.js
     document.getElementById('myForm').addEventListener('submit', async event => {
       event.preventDefault()
-      const result = await fetch(`/.netlify/functions/searchIndex?search=${event.target.searchText.value}`).then(x => x.json())
+      const result = await fetch(`/.netlify/functions/searchIndex?search=${event.target.searchText.value}&limit=25`).then(x => x.json())
       document.getElementById('result').innerText = JSON.stringify(result, null, 2)
     })
     ```
+
+You can use an optional `limit` parameter to limit the length of returned results.
 
 Under the hood, the search function uses [fuse.js](https://fusejs.io/) and in future we may expose more configurations for this.
 

--- a/fixtures/manifest.yml
+++ b/fixtures/manifest.yml
@@ -1,0 +1,4 @@
+name: 'articles-generator'
+
+inputs:
+  - name: folder

--- a/functionTemplate/{{searchIndex}}.js
+++ b/functionTemplate/{{searchIndex}}.js
@@ -9,7 +9,7 @@ searchIndex = Object.entries(searchIndex).map(([k, v]) => {
 });
 var options = {
   shouldSort: true,
-  threshold: 0.6,
+  threshold: 0.5,
   location: 0,
   distance: 100,
   maxPatternLength: 32,
@@ -28,18 +28,32 @@ var options = {
 var fuse = new Fuse(searchIndex, options);
 
 exports.handler = async (event) => {
-  const searchTerm =
-    event.queryStringParameters.search || event.queryStringParameters.s;
+  const {
+    s,
+    search,
+    limit
+  } = event.queryStringParameters
+  
+  const searchTerm = search || s
   if (typeof searchTerm === 'undefined') {
     return {
       statusCode: 400,
       body:
         'no search term specified, query this function with /?search=searchTerm or /?s=searchTerm'
-    };
+    }
   }
-  var result = fuse.search(searchTerm);
+  let parsedInt
+  if (limit) {
+    maybeInt = parseInt(limit)
+    if (maybeInt !== NaN) {
+      parsedInt = maybeInt
+    }
+  }
+
+  const result = fuse.search(searchTerm);
+  
   return {
     statusCode: 200,
-    body: JSON.stringify(result)
+    body: JSON.stringify(parsedInt ? result.slice(0, parsedInt) : result)
   };
 };

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,8 @@
   functions = "fixtures/functions"
 
 [[plugins]]
+package = "@netlify/plugin-local-install-core"
+[[plugins]]
   package = "./fixtures/generator"
 [[plugins]]
   package = "./index.js"


### PR DESCRIPTION
Following #19, I lowered the fuzzy search threshold to .5, as its results seem to be closer to what you would expect (cuts number of docs by ~ half if the search is specific enough). If anyone is interested, I can make search options configurable via build inputs.

I also added a `limit` query string parameter that limits the length of returned results.

Other changes are related to new plugin expected structure (https://github.com/netlify/build#anatomy-of-a-plugin).