### PR TITLE
Updated documentation around file excludes

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ Supplying `null` to both `generatedFunctionName` and `publishDirJSONFileName` wo
 
 #### Exclude files
 
-Your project probably contains some content files that you don't want your users to search. Pass an array of paths (or regex) to the files you don’t want to be indexed to dismiss them:
+Your project probably contains some content files that you don't want your users to search (e.g. paginated pages such as `/page/1/index.html`). Pass an array of paths (or regex) to the files you don’t want to be indexed to dismiss them:
 
 ```yml
 [[plugins]]
   package = netlify-plugin-search-index
     [plugins.inputs] = 
-      exclude = ['/ignore-this-file.html', /^\/devnull\/.*/]
+      exclude = ['/ignore-this-file.html', '''\/page\/''']
 ```
 
 #### Search params


### PR DESCRIPTION
I was stuck on this for a while, so thought it might be useful to update the doc for others who might experience the same problem.

I wanted to exclude a list of paginated pages `/page/1/index.html` by doing `exclude = [/^\/page\/.*/]`. Unfortunately, toml parser throw an error on Netlify.

<img width="1172" alt="Screenshot 2020-08-03 at 22 37 39" src="https://user-images.githubusercontent.com/1476807/89230314-f51b1100-d5da-11ea-874c-9046d7d1396a.png">

After changing the exclude to `exclude = ['''\/page\/''']`, everything was working fine.